### PR TITLE
minikube get-k8s-versions is no longer a valid command

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,6 @@ brew install minikube
 minikube start
 minikube status
 minikube ip
-minikube get-k8s-versions
 ```
 
 ### You can start a new k8s-cluster with a specific version by using


### PR DESCRIPTION
See https://github.com/kubernetes/minikube/issues/3179
Greetings from Harald!